### PR TITLE
Mark Spring application type as none

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,15 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+			<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-json</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.shell</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 logging.level.root=OFF
 spring.main.banner-mode=off
+spring.main.web-application-type=none


### PR DESCRIPTION
Since it's shell app, we can avoid starting Netty server. We need webflux starter only to pull required dependency for webClient.